### PR TITLE
Triton rope

### DIFF
--- a/full_example.ipynb
+++ b/full_example.ipynb
@@ -177,7 +177,7 @@
     "    next_inputs = tokenizer.pad(dict(input_ids=next_input_tokens), padding_side='left', return_tensors='pt').to(device)\n",
     "\n",
     "    if inference_step % print_every_steps == 0:\n",
-    "        clear_output(True)  # # display current progress\n",
+    "        clear_output(True)  # display current progress\n",
     "        output_parts = [f\"[**Problem:** {problem}]\\n\\n\"]\n",
     "        output_parts.append(Formatting.history_header + Formatting.SEP + tokenizer.decode(history))\n",
     "        output_parts.append(Formatting.current_step_header)\n",

--- a/full_example.ipynb
+++ b/full_example.ipynb
@@ -167,7 +167,7 @@
     "            worker_tokens.clear()\n",
     "            start_msg = Formatting.get_step_prefix(worker_name, current_step_index_by_worker[worker_index])\n",
     "            if tokens_since_last_wait > insert_s1_prompt_every_tokens:\n",
-    "                start_msg += Formatting.s1_collab_message   # <-- insert \"Wait, am I doing redundant work?\"ii\n",
+    "                start_msg += Formatting.s1_collab_message   # <-- insert \"Wait, am I doing redundant work?\"\n",
     "                tokens_since_last_wait = 0\n",
     "            worker_tokens.extend(tokenizer.encode(start_msg, add_special_tokens=False))\n",
     "            cache_common.append_from(cm.cache_structure[worker_index][-1])\n",

--- a/shared_cache/cache_block.py
+++ b/shared_cache/cache_block.py
@@ -251,7 +251,7 @@ def _apply_rotary_cos_sin_triton(x: torch.Tensor, cos: torch.Tensor, sin: torch.
     assert x.shape[-1] == cos.shape[-1]
     batch_size, num_kv_heads, length, head_dim = x.shape
     out = torch.empty_like(x)
-    grid = lambda meta: (triton.cdiv(num_kv_heads * length, meta['B0']), triton.cdiv(head_dim, meta['B1']))
+    grid = lambda meta: (triton.cdiv(batch_size * num_kv_heads * length, meta['B0']), triton.cdiv(head_dim, meta['B1']))
     apply_rotary_cos_sin_kernel[grid](x, cos, sin, out, batch_size, num_kv_heads, head_dim, length, B0=1, B1=32)
     return out
 

--- a/shared_cache/cache_block.py
+++ b/shared_cache/cache_block.py
@@ -172,6 +172,7 @@ def compute_rotary_cos_sin_kernel(
     tl.store(sin_ptr + offsets, sin, offsets < PE_DIM)
     tl.store(sin_ptr + offsets + PE_DIM, sin, offsets < PE_DIM)
 
+
 def _compute_rotary_cos_sin_triton(
     offset: int, 
     inv_freq: torch.Tensor,
@@ -193,7 +194,6 @@ def _compute_rotary_cos_sin_triton(
 
 @torch.compile(dynamic=None, disable=bool(int(os.environ.get("HOGWILD_NO_COMPILE", False))))
 def _apply_rotary_cos_sin(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
-    # return x
     """Rotates half the hidden dims of the input."""
     x_dim, pe_dim = x.shape[-1], cos.shape[-1]
     x_pe = x
@@ -221,39 +221,39 @@ def apply_rotary_cos_sin_kernel(
     B0: tl.constexpr,
     B1: tl.constexpr
 ):
-  pid_0 = tl.program_id(0)
-  pid_1 = tl.program_id(1)
+    pid_0 = tl.program_id(0)
+    pid_1 = tl.program_id(1)
 
-  i_range = pid_0 * B0 + tl.arange(0, B0)
-  j1_range = pid_1 * B1 + tl.arange(0, B1)
-  j2_range = j1_range + HEAD_DIM // 2
+    i_range = pid_0 * B0 + tl.arange(0, B0)
+    j1_range = pid_1 * B1 + tl.arange(0, B1)
+    j2_range = j1_range + HEAD_DIM // 2
 
-  x1_range = i_range[:, None] * HEAD_DIM + j1_range[None, :]
-  x1_mask = (i_range[:, None] < BATCH_SIZE * NUM_KV_HEADS * L) & (j1_range[None, :] < HEAD_DIM // 2)
+    x1_range = i_range[:, None] * HEAD_DIM + j1_range[None, :]
+    x1_mask = (i_range[:, None] < BATCH_SIZE * NUM_KV_HEADS * L) & (j1_range[None, :] < HEAD_DIM // 2)
 
-  x2_range = i_range[:, None] * HEAD_DIM + j2_range[None, :]
-  x2_mask = (i_range[:, None] < BATCH_SIZE * NUM_KV_HEADS * L) & (j2_range[None, :] < HEAD_DIM)
+    x2_range = i_range[:, None] * HEAD_DIM + j2_range[None, :]
+    x2_mask = (i_range[:, None] < BATCH_SIZE * NUM_KV_HEADS * L) & (j2_range[None, :] < HEAD_DIM)
 
-  x1 = tl.load(x_ptr + x1_range, x1_mask, 0)
-  x2 = tl.load(x_ptr + x2_range, x2_mask, 0)
+    x1 = tl.load(x_ptr + x1_range, x1_mask, 0)
+    x2 = tl.load(x_ptr + x2_range, x2_mask, 0)
 
-  sin1 = tl.load(sin_ptr + j1_range, j1_range < HEAD_DIM // 2, 0)
-  sin2 = tl.load(sin_ptr + j2_range, j2_range < HEAD_DIM, 0)
+    sin1 = tl.load(sin_ptr + j1_range, j1_range < HEAD_DIM // 2, 0)
+    sin2 = tl.load(sin_ptr + j2_range, j2_range < HEAD_DIM, 0)
 
-  cos1 = tl.load(cos_ptr + j1_range, j1_range < HEAD_DIM // 2, 0)
-  cos2 = tl.load(cos_ptr + j2_range, j2_range < HEAD_DIM, 0)
+    cos1 = tl.load(cos_ptr + j1_range, j1_range < HEAD_DIM // 2, 0)
+    cos2 = tl.load(cos_ptr + j2_range, j2_range < HEAD_DIM, 0)
 
-  tl.store(out_ptr + x1_range, cos1 * x1 - sin1 * x2, x1_mask)
-  tl.store(out_ptr + x2_range, cos2 * x2 + sin2 * x1, x2_mask)
+    tl.store(out_ptr + x1_range, cos1 * x1 - sin1 * x2, x1_mask)
+    tl.store(out_ptr + x2_range, cos2 * x2 + sin2 * x1, x2_mask)
 
 
 def _apply_rotary_cos_sin_triton(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
-  assert x.shape[-1] == cos.shape[-1]
-  batch_size, num_kv_heads, length, head_dim = x.shape
-  out = torch.empty_like(x)
-  grid = lambda meta: (triton.cdiv(num_kv_heads * length, meta['B0']), triton.cdiv(head_dim, meta['B1']))
-  apply_rotary_cos_sin_kernel[grid](x, cos, sin, out, batch_size, num_kv_heads, head_dim, length, B0=1, B1=32)
-  return out
+    assert x.shape[-1] == cos.shape[-1]
+    batch_size, num_kv_heads, length, head_dim = x.shape
+    out = torch.empty_like(x)
+    grid = lambda meta: (triton.cdiv(num_kv_heads * length, meta['B0']), triton.cdiv(head_dim, meta['B1']))
+    apply_rotary_cos_sin_kernel[grid](x, cos, sin, out, batch_size, num_kv_heads, head_dim, length, B0=1, B1=32)
+    return out
 
 
 _CACHED_ROPE_PARAMS = _CACHED_ROPE_INIT = None  # this is a makeshift functools.lru_cache w/o hashing


### PR DESCRIPTION
This PR adds `triton` implementation for RoPE operations.

Triton implementation turns out to be slightly faster than original compiled version:

end-2-end `generation latency`

* **baseline (torch)** - 7.59it/s
* **triton** - 8.65it/s 

Triton implementation can be turned on via `APPLY_ROTARY_COS_SIN_TRITON` env variable set to `1`.